### PR TITLE
Fixed Dockerfile Image

### DIFF
--- a/microservices/graphql/Dockerfile
+++ b/microservices/graphql/Dockerfile
@@ -24,7 +24,7 @@ RUN GO111MODULE=on go build -o /go/src/ ./cmd/main.go
 #     openssl rsa -in /etc/ssl/private.pem -outform PEM -pubout -out /etc/ssl/public.pem
 
 # Build the final environment for deploy go app
-FROM alpine:3.18
+FROM public.ecr.aws/docker/library/alpine:3.18
 
 WORKDIR /usr/bin
 


### PR DESCRIPTION
To bring from AWS, not Docker.io. (To avoid rate limit)